### PR TITLE
Fix README newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # pearl_service_factory-0
+


### PR DESCRIPTION
## Summary
- add missing newline at EOF in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687122da44108327bb07e30fd25ba84a